### PR TITLE
Add notifications for when break starts and break ends

### DIFF
--- a/js/notifications/breakTime.js
+++ b/js/notifications/breakTime.js
@@ -1,0 +1,19 @@
+import { Notification } from './notification.js'
+
+export class BreakTime extends Notification {
+
+  constructor() {
+    super('bh-notification-break')
+  }
+
+  getText() {
+    return {
+      type: 'basic',
+      title: 'Break Helper',
+      message: "You're on a break",
+      iconUrl: 'icon128.png',
+      requireInteraction: false,
+    }
+  }
+
+}

--- a/js/notifications/notification.js
+++ b/js/notifications/notification.js
@@ -25,6 +25,10 @@ export class Notification {
     }
   }
 
+  tick() {
+
+  }
+
   update() {
     chrome.notifications.update(this.notificationId, this.getText())
   }
@@ -56,6 +60,7 @@ export class Notification {
     if (notificationId === this.notificationId && byUser) {
       this.closedByUser()
     }
+    this.hide()
   }
 
   firstButtonClick() {

--- a/js/notifications/workTime.js
+++ b/js/notifications/workTime.js
@@ -1,0 +1,19 @@
+import { Notification } from './notification.js'
+
+export class WorkTime extends Notification {
+
+  constructor() {
+    super('bh-notification-work')
+  }
+
+  getText() {
+    return {
+      type: 'basic',
+      title: 'Break Helper',
+      message: "Break time's up. Let's get back to work!",
+      iconUrl: 'icon128.png',
+      requireInteraction: false,
+    }
+  }
+
+}

--- a/js/states/break.js
+++ b/js/states/break.js
@@ -3,6 +3,8 @@ import { Badge } from '../badge.js'
 import { Working } from './working.js'
 import { Stopped } from './stopped.js'
 import { Sound } from '../sound.js'
+import { BreakTime } from '../notifications/breakTime.js'
+import { WorkTime } from '../notifications/workTime.js'
 
 export class Break {
 
@@ -10,6 +12,7 @@ export class Break {
     this.app = app
     this.timer = new Timer(this.tick.bind(this))
     this.badge = new Badge()
+    this.notification = new BreakTime()
     this.name = 'break'
   }
 
@@ -17,6 +20,7 @@ export class Break {
     const timeLeft = parseInt(this.app.settings.getActiveRule().breakTime, 10)
     this.timer.start(timeLeft)
     this.badge.show(timeLeft)
+    this.notification.show()
   }
 
   tick(timerState, timeLeft) {
@@ -32,6 +36,7 @@ export class Break {
   work() {
     this.timer.stop()
     this.badge.hide()
+    this._showWorkNotification()
     this.app.changeState(new Working(this.app))
   }
 
@@ -52,5 +57,9 @@ export class Break {
     if (parseInt(this.app.settings.get('playSound'), 10)) {
       (new Sound()).play()
     }
+  }
+
+  _showWorkNotification() {
+    (new WorkTime()).show()
   }
 }


### PR DESCRIPTION
This is a further step on refactoring previous code and adds two notifications:
- when break starts
- when break ends and work starts

Previously this was the case, but got removed during refactorings.